### PR TITLE
Fix typo in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-filter == 2.4.0
 django-fontawesome-5 == 1.0.18
 django-rest-knox == 4.1.0
 djangorestframework == 3.12.2
-mardown == 3.3.4
+markdown == 3.3.4
 mod-wsgi == 4.6.8
 postgres == 3.0.0
 pytz == 2019.1


### PR DESCRIPTION
Assuming this is just missing a `k` :)

```
ERROR: Could not find a version that satisfies the requirement mardown==3.3.4
ERROR: No matching distribution found for mardown==3.3.4
```