### PR TITLE
Fix loading of .env file with python-dotenv

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -7,7 +7,7 @@ import dotenv
 
 
 def main():
-    dotenv.load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'receptor'))
+    dotenv.load_dotenv(os.path.join(os.path.dirname(os.path.dirname(__file__)), 'receptor', '.env'))
 
     os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'receptor.settings')
     try:


### PR DESCRIPTION
It looks like `load_dotenv` from python-dot-env expects a path straight to the file, rather than to the folder the file is in.